### PR TITLE
Support newer bravia models

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/src/androidTest/assets/controls.json
+++ b/app/src/androidTest/assets/controls.json
@@ -107,7 +107,13 @@
         "OneTouchTimeRec": "AAAAAgAAABoAAABkAw==",
         "OneTouchView": "AAAAAgAAABoAAABlAw==",
         "OneTouchRec": "AAAAAgAAABoAAABiAw==",
-        "OneTouchStop": "AAAAAgAAABoAAABjAw=="
+        "OneTouchStop": "AAAAAgAAABoAAABjAw==",
+        "TvPower": "AAAAAQAAAAEAAAAVAw==",
+        "TvInput": "AAAAAQAAAAEAAAAlAw==",
+        "MediaAudioTrack": "AAAAAQAAAAEAAAAXAw==",
+        "Audiosystem": "AAAAAgAAAMQAAAAiAw==",
+        "WakeUp": "AAAAAQAAAAEAAAAuAw==",
+        "Sleep": "AAAAAQAAAAEAAAAvAw=="
       },
       "sourceList": [
         "tv:dvbc",
@@ -4790,7 +4796,13 @@
         "OneTouchTimeRec": "AAAAAgAAABoAAABkAw==",
         "OneTouchView": "AAAAAgAAABoAAABlAw==",
         "OneTouchRec": "AAAAAgAAABoAAABiAw==",
-        "OneTouchStop": "AAAAAgAAABoAAABjAw=="
+        "OneTouchStop": "AAAAAgAAABoAAABjAw==",
+        "TvPower": "AAAAAQAAAAEAAAAVAw==",
+        "TvInput": "AAAAAQAAAAEAAAAlAw==",
+        "MediaAudioTrack": "AAAAAQAAAAEAAAAXAw==",
+        "Audiosystem": "AAAAAgAAAMQAAAAiAw==",
+        "WakeUp": "AAAAAQAAAAEAAAAuAw==",
+        "Sleep": "AAAAAQAAAAEAAAAvAw=="
       },
       "programList": [
         {

--- a/app/src/main/assets/controls.json
+++ b/app/src/main/assets/controls.json
@@ -107,7 +107,13 @@
         "OneTouchTimeRec": "AAAAAgAAABoAAABkAw==",
         "OneTouchView": "AAAAAgAAABoAAABlAw==",
         "OneTouchRec": "AAAAAgAAABoAAABiAw==",
-        "OneTouchStop": "AAAAAgAAABoAAABjAw=="
+        "OneTouchStop": "AAAAAgAAABoAAABjAw==",
+        "TvPower": "AAAAAQAAAAEAAAAVAw==",
+        "TvInput": "AAAAAQAAAAEAAAAlAw==",
+        "MediaAudioTrack": "AAAAAQAAAAEAAAAXAw==",
+        "Audiosystem": "AAAAAgAAAMQAAAAiAw==",
+        "WakeUp": "AAAAAQAAAAEAAAAuAw==",
+        "Sleep": "AAAAAQAAAAEAAAAvAw=="
       },
       "sourceList": [
         "tv:dvbc",
@@ -4790,7 +4796,13 @@
         "OneTouchTimeRec": "AAAAAgAAABoAAABkAw==",
         "OneTouchView": "AAAAAgAAABoAAABlAw==",
         "OneTouchRec": "AAAAAgAAABoAAABiAw==",
-        "OneTouchStop": "AAAAAgAAABoAAABjAw=="
+        "OneTouchStop": "AAAAAgAAABoAAABjAw==",
+        "TvPower": "AAAAAQAAAAEAAAAVAw==",
+        "TvInput": "AAAAAQAAAAEAAAAlAw==",
+        "MediaAudioTrack": "AAAAAQAAAAEAAAAXAw==",
+        "Audiosystem": "AAAAAgAAAMQAAAAiAw==",
+        "WakeUp": "AAAAAQAAAAEAAAAuAw==",
+        "Sleep": "AAAAAQAAAAEAAAAvAw=="
       },
       "programList": [
         {

--- a/app/src/main/java/org/andan/android/tvbrowser/sonycontrolplugin/network/SonyService.kt
+++ b/app/src/main/java/org/andan/android/tvbrowser/sonycontrolplugin/network/SonyService.kt
@@ -173,7 +173,8 @@ object SonyServiceUtil {
   const val SONY_AV_CONTENT_ENDPOINT = "/sony/avContent"
   const val SONY_ACCESS_CONTROL_ENDPOINT = "/sony/accessControl"
   const val SONY_SYSTEM_ENDPOINT = "/sony/system"
-  const val SONY_IRCC_ENDPOINT = "/sony/IRCC"
+  const val SONY_IRCC_ENDPOINT = "/sony/ircc"
+  const val SONY_IRCC_ENDPOINT_LEGACY = "/sony/IRCC"
   const val SONY_IRCC_REQUEST_TEMPLATE =
       "<s:Envelope\n" +
           "    xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"\n" +

--- a/app/src/main/java/org/andan/android/tvbrowser/sonycontrolplugin/repository/SonyControlRepository.kt
+++ b/app/src/main/java/org/andan/android/tvbrowser/sonycontrolplugin/repository/SonyControlRepository.kt
@@ -467,12 +467,30 @@ constructor(
   }
 
   suspend fun sendCommand(command: String): Result<Any> {
-    val code = getActiveSonyControl()!!.commandMap[command]
+    val commandMap = getActiveSonyControl()!!.commandMap
+    var code = commandMap[command]
+    if (code.isNullOrBlank()) {
+      // Fallback to legacy command name for older Bravia models which report
+      // PowerOff/Input/Audio in their commandList instead of TvPower/TvInput/MediaAudioTrack.
+      val alias = LEGACY_COMMAND_ALIASES[command]
+      if (alias != null) {
+        code = commandMap[alias]
+        Timber.d("sendCommand: $command not found, falling back to legacy alias $alias")
+      }
+    }
     Timber.d("sendCommand: $command $code")
     if (!code.isNullOrBlank()) {
       return sendIRCC(code)
     }
     return Result.Error("No valid code for command: $command", -1)
+  }
+
+  companion object {
+    private val LEGACY_COMMAND_ALIASES = mapOf(
+        "TvPower" to "PowerOff",
+        "TvInput" to "Input",
+        "MediaAudioTrack" to "Audio",
+    )
   }
 
   suspend fun sendIRCC(code: String): Result<Any> {
@@ -485,11 +503,21 @@ constructor(
         val requestBody: RequestBody = requestBodyText.toRequestBody("text/xml".toMediaTypeOrNull())
         Timber.d("sendIRCC: $requestBodyText")
         try {
-          val response =
+          var response =
               api.sendIRCC(
                   "http://" + sessionManager.hostname + SonyServiceUtil.SONY_IRCC_ENDPOINT,
                   requestBody)
           Timber.d("response: $response")
+          if (!response.isSuccessful) {
+            // Fallback for older Bravia models whose nginx is case-sensitive
+            // and only accepts the uppercase /sony/IRCC path.
+            Timber.d("IRCC lowercase path failed (${response.code()}), trying legacy uppercase /sony/IRCC")
+            response =
+                api.sendIRCC(
+                    "http://" + sessionManager.hostname + SonyServiceUtil.SONY_IRCC_ENDPOINT_LEGACY,
+                    requestBody)
+            Timber.d("legacy response: $response")
+          }
           if (!response.isSuccessful) {
             Timber.e("IRCC send not successful: ${response.message()}")
             return@withContext Result.Error<Any>(

--- a/app/src/main/java/org/andan/android/tvbrowser/sonycontrolplugin/ui/screens/remotecontrol/RemoteControlScreen.kt
+++ b/app/src/main/java/org/andan/android/tvbrowser/sonycontrolplugin/ui/screens/remotecontrol/RemoteControlScreen.kt
@@ -121,7 +121,7 @@ private fun RemoteControlContent() {
         Spacer(modifier = Modifier.height(24.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
           RemoteControlIconButton(
-              command = "Input", painter = painterResource(id = R.drawable.outline_input_24))
+              command = "TvInput", painter = painterResource(id = R.drawable.outline_input_24))
           RemoteControlTextButton(command = "GGuide", text = "GUIDE")
           RemoteControlTextButton(
               // modifier = Modifier.background(color=colorResource(id = R.color.buttonBlue)),
@@ -129,9 +129,23 @@ private fun RemoteControlContent() {
               backgroundColor = colorResource(id = R.color.buttonBlue),
               text = "SEN")
           RemoteControlIconButton(
-              command = "PowerOff",
+              command = "TvPower",
               backgroundColor = colorResource(id = R.color.buttonGreen),
               painter = painterResource(id = R.drawable.outline_power_settings_new_24))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+          RemoteControlTextButton(
+              command = "WakeUp",
+              backgroundColor = colorResource(id = R.color.buttonGreen),
+              text = "ON")
+          RemoteControlTextButton(
+              command = "Sleep",
+              text = "OFF")
+          RemoteControlTextButton(
+              command = "Audiosystem",
+              backgroundColor = colorResource(id = R.color.buttonBlue),
+              text = "SPEAKER")
         }
         Spacer(modifier = Modifier.height(24.dp))
         Box(
@@ -425,7 +439,7 @@ private fun RemoteControlContent() {
               command = "ClosedCaption",
               painter = painterResource(id = R.drawable.ic_action_subtitle))
           RemoteControlTextButton(
-              command = "Audio",
+              command = "MediaAudioTrack",
               text = "AUDIO",
           )
           RemoteControlIconButton(

--- a/app/src/test/data/controls.json
+++ b/app/src/test/data/controls.json
@@ -107,7 +107,13 @@
         "OneTouchTimeRec": "AAAAAgAAABoAAABkAw==",
         "OneTouchView": "AAAAAgAAABoAAABlAw==",
         "OneTouchRec": "AAAAAgAAABoAAABiAw==",
-        "OneTouchStop": "AAAAAgAAABoAAABjAw=="
+        "OneTouchStop": "AAAAAgAAABoAAABjAw==",
+        "TvPower": "AAAAAQAAAAEAAAAVAw==",
+        "TvInput": "AAAAAQAAAAEAAAAlAw==",
+        "MediaAudioTrack": "AAAAAQAAAAEAAAAXAw==",
+        "Audiosystem": "AAAAAgAAAMQAAAAiAw==",
+        "WakeUp": "AAAAAQAAAAEAAAAuAw==",
+        "Sleep": "AAAAAQAAAAEAAAAvAw=="
       },
       "sourceList": [
         "tv:dvbc",
@@ -4790,7 +4796,13 @@
         "OneTouchTimeRec": "AAAAAgAAABoAAABkAw==",
         "OneTouchView": "AAAAAgAAABoAAABlAw==",
         "OneTouchRec": "AAAAAgAAABoAAABiAw==",
-        "OneTouchStop": "AAAAAgAAABoAAABjAw=="
+        "OneTouchStop": "AAAAAgAAABoAAABjAw==",
+        "TvPower": "AAAAAQAAAAEAAAAVAw==",
+        "TvInput": "AAAAAQAAAAEAAAAlAw==",
+        "MediaAudioTrack": "AAAAAQAAAAEAAAAXAw==",
+        "Audiosystem": "AAAAAgAAAMQAAAAiAw==",
+        "WakeUp": "AAAAAQAAAAEAAAAuAw==",
+        "Sleep": "AAAAAQAAAAEAAAAvAw=="
       },
       "programList": [
         {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = "0.36.0"
-androidGradlePlugin = "8.7.2"
+androidGradlePlugin = "8.13.2"
 androidxAppCompat = "1.7.0"
 androidxComposeBom = "2024.10.00"
 androidxCore = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Oct 05 12:11:09 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Default IRCC endpoint to /sony/ircc with fallback to legacy /sony/IRCC
- Bind power/input/audio buttons to new TvPower/TvInput/MediaAudioTrack command names with alias fallback for older models
- Add dedicated WakeUp, Sleep, and Audiosystem buttons to remote UI
- Extend bundled controls.json sample data with new command aliases